### PR TITLE
Allow users props to override defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,11 @@ class Mailchimp extends React.Component {
     return (
       <form onSubmit={this.handleSubmit.bind(this)} className={className}>
         {fields.map(input =>
-          <input
-            {...input}
+          <input       
             key={input.name}
             onChange={({ target }) => this.setState({ [input.name]: target.value })}
             defaultValue={this.state[input.name]}
+            {...input}
           />
         )}
         <button


### PR DESCRIPTION
My use case here is I want a hidden field with a predefined value. When passing `defaultValue` it's being overridden by `{this.state[input.name]}`